### PR TITLE
Remove getInitialProps from _app for automatic static optimization

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -171,13 +171,3 @@ export default function App({ Component, pageProps }) {
     </Container>
   );
 }
-
-App.getInitialProps = async ({ Component, ctx }) => {
-  let pageProps = {};
-
-  if (Component.getInitialProps) {
-    pageProps = await Component.getInitialProps(ctx);
-  }
-
-  return { pageProps };
-};


### PR DESCRIPTION
This opts into the automatic static optimization if your pages don't use getInitialProps. That is if you upgrade to Next.js 9.