### PR TITLE
fix: 'dynamic' import statement in Editor Panel

### DIFF
--- a/components/EditorPanel.tsx
+++ b/components/EditorPanel.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip
 } from "evergreen-ui";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import dynamic from "next-server/dynamic";
+import dynamic from "next/dynamic";
 import copy from "clipboard-copy";
 import { getWorker, Wrapper } from "@utils/workerWrapper";
 import Npm from "@assets/svgs/Npm";


### PR DESCRIPTION
change import statement form
import dynamic from 'next-server/dynamic'
to
import dynamic form 'next/dynamic'

closes #152 
![next-server-dynamic](https://user-images.githubusercontent.com/13845070/67163351-7b879e80-f38b-11e9-9f19-d571f441c873.gif)
