### PR TITLE
Error page: Pane indentation fix

### DIFF
--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -6,7 +6,7 @@ import Error500 from "@assets/svgs/Error500";
 
 export default function Error({ statusCode }) {
   return (
-    <Pane display="flex" flex={1} paddingTop={200}>
+    <Pane display="flex" flex={1} alignItems="center">
       <Pane display="flex" flexDirection="column" alignItems="center" flex={1}>
         {statusCode === 404 ? (
           <>


### PR DESCRIPTION
<img width="1438" alt="Screenshot 2020-06-25 at 9 08 03 AM 1" src="https://user-images.githubusercontent.com/10559670/85650565-6e157780-b6c3-11ea-8cff-de0b575d5d0a.png">
The image isn't aligned in the centre and breaks in the 13 inch mac with default resolution.