### PR TITLE
Added type structure setting for json-to-typescript

### DIFF
--- a/pages/json-to-typescript.tsx
+++ b/pages/json-to-typescript.tsx
@@ -1,18 +1,60 @@
 import ConversionPanel from "@components/ConversionPanel";
+import { EditorPanelProps } from "@components/EditorPanel";
+import Form, { InputType } from "@components/Form";
+import { useSettings } from "@hooks/useSettings";
 import * as React from "react";
 import { useCallback } from "react";
 
+interface Settings {
+  typealias: boolean;
+}
+
+const formFields = [
+  {
+    type: InputType.SWITCH,
+    key: "typealias",
+    label: "Create Mono Type"
+  }
+];
+
 export default function JsonToTypescript() {
-  const transformer = useCallback(async ({ value }) => {
-    const { run } = await import("json_typegen_wasm");
-    return run(
-      "Root",
-      value,
-      JSON.stringify({
-        output_mode: "typescript"
-      })
-    );
-  }, []);
+  const name = "JSON to Typescript";
+
+  const [settings, setSettings] = useSettings(name, {
+    typealias: false
+  });
+
+  const transformer = useCallback(
+    async ({ value }) => {
+      const { run } = await import("json_typegen_wasm");
+      return run(
+        "Root",
+        value,
+        JSON.stringify({
+          output_mode: settings.typealias
+            ? "typescript/typealias"
+            : "typescript"
+        })
+      );
+    },
+    [settings]
+  );
+
+  const getSettingsElement = useCallback<EditorPanelProps["settingElement"]>(
+    ({ open, toggle }) => {
+      return (
+        <Form<Settings>
+          title={name}
+          onSubmit={setSettings}
+          open={open}
+          toggle={toggle}
+          formsFields={formFields}
+          initialValues={settings}
+        />
+      );
+    },
+    []
+  );
 
   return (
     <ConversionPanel
@@ -21,6 +63,8 @@ export default function JsonToTypescript() {
       editorLanguage="json"
       resultTitle="TypeScript"
       resultLanguage={"typescript"}
+      editorSettingsElement={getSettingsElement}
+      settings={settings}
     />
   );
 }


### PR DESCRIPTION
Added a toggle switch to the `json-to-typescript` to modify the structure of the generated type.

Input
```json
{
  "a": true,
  "b": {
    "c": true
  }
}
```

Output (default setting)
```ts
export interface Root {
  a: boolean
  b: B
}

export interface B {
  c: boolean
}

```

Output (toggled setting)
```ts
export type Root = {
  a: boolean
  b: {
    c: boolean
  }
}
```