### PR TITLE
Add JSON to Zod Schema converter

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "is-svg": "^4.3.1",
     "json-schema-to-typescript": "^10.1.4",
     "json-to-go": "gist:0d0b8324131c80eeb7e1df20001be32f",
+    "json-to-zod": "^1.1.2",
     "json-ts": "^1.6.4",
     "json_typegen_wasm": "^0.7.0",
     "jsonld": "^5.2.0",

--- a/pages/json-to-zod.tsx
+++ b/pages/json-to-zod.tsx
@@ -1,0 +1,62 @@
+import ConversionPanel from "@components/ConversionPanel";
+import { EditorPanelProps } from "@components/EditorPanel";
+import Form, { InputType } from "@components/Form";
+import { useSettings } from "@hooks/useSettings";
+import * as React from "react";
+import { useCallback } from "react";
+
+interface Settings {
+  rootName: string;
+}
+
+const formFields = [
+  {
+    type: InputType.TEXT_INPUT,
+    key: "rootName",
+    label: "Root Schema Name"
+  }
+];
+
+export default function JsonToZod() {
+  const name = "JSON to Zod Schema";
+
+  const [settings, setSettings] = useSettings(name, {
+    rootName: "schema"
+  });
+
+  const transformer = useCallback(
+    async ({ value }) => {
+      const { jsonToZod } = await import("json-to-zod");
+      return jsonToZod(JSON.parse(value), settings.rootName, true);
+    },
+    [settings]
+  );
+
+  const getSettingsElement = useCallback<EditorPanelProps["settingElement"]>(
+    ({ open, toggle }) => {
+      return (
+        <Form<Settings>
+          title={name}
+          onSubmit={setSettings}
+          open={open}
+          toggle={toggle}
+          formsFields={formFields}
+          initialValues={settings}
+        />
+      );
+    },
+    []
+  );
+
+  return (
+    <ConversionPanel
+      transformer={transformer}
+      editorTitle="JSON"
+      editorLanguage="json"
+      resultTitle="Zod Schema"
+      resultLanguage={"typescript"}
+      editorSettingsElement={getSettingsElement}
+      settings={settings}
+    />
+  );
+}

--- a/utils/routes.tsx
+++ b/utils/routes.tsx
@@ -141,6 +141,12 @@ export const categorizedRoutes = [
         path: "/json-to-toml",
         packageUrl: "https://www.npmjs.com/package/@iarna/toml",
         packageName: "@iarna/toml"
+      },
+      {
+        label: "to Zod Schema",
+        path: "/json-to-zod",
+        packageUrl: "https://github.com/rsinohara/json-to-zod",
+        packageName: "json-to-zod"
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5997,6 +5997,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "1.0.0"
   resolved "https://gist.github.com/0d0b8324131c80eeb7e1df20001be32f.git#3c19dec6061daff466b13783fea94c49e4f62e86"
 
+json-to-zod@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/json-to-zod/-/json-to-zod-1.1.2.tgz#626d4432f329c51089120858c9404234567dda1b"
+  integrity sha512-6YDvnY8oOS5v1H1CWUvfNJkCI3SGbmCwWMytndPHzwyrr1K9ayNXL4rvOSf7WCy3c3Pxu2brvt4idZCkKh9gfQ==
+  dependencies:
+    prettier "^2.3.2"
+
 json-ts@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/json-ts/-/json-ts-1.6.4.tgz#e4423b8ccdb3069306f4727d6a579790675abbd0"
@@ -7852,6 +7859,11 @@ prettier@^2.1.1, prettier@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
+prettier@^2.3.2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR is for a converter from JSON to a [Zod](https://zod.dev/) schema, a popular TypeScript-first schema validation library.

If this is merged, I'd like to add other Zod converters, as there are many pre-built solutions for this mentioned in their [ecosystem](https://zod.dev/?id=ecosystem) section.

These could include:

- [json-schema-to-zod](https://github.com/StefanTerdell/json-schema-to-zod): Convert your [JSON Schemas](https://json-schema.org/) into Zod schemas.
- [ts-to-zod](https://github.com/fabien0102/ts-to-zod): Convert TypeScript definitions into Zod schemas.
- [zod-to-json-schema](https://github.com/StefanTerdell/zod-to-json-schema): Convert your Zod schemas into [JSON Schemas](https://json-schema.org/).
- [zod-to-ts](https://github.com/sachinraja/zod-to-ts): Generate TypeScript definitions from Zod schemas.

And potentially a few others.

One thing I wanted to make sure of, in the `routes.tsx` file, are GitHub or NPM links preferred for the `packageUrl` field?  I saw that most of them are GitHub links so that's what I went with but I see that some are NPM so I wanted to make sure.

Besides that, let me know if you need any changes in order to merge!