### PR TITLE
Add a Prettier config file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "requirePragma": false,
+  "insertPragma": false,
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
Without a prettier config file, often times the settings of an individual user's editor will take precedence and cause files to get formatted differently than they already are.

For example, I have "Format on Save" turned on in VSCode and Prettier is my editor's default formatter, so my personal defaults end up causing every file to change on save.

This PR is meant to define a setting for each of the configuration options available in prettier so that editor defaults won't interfere.  I made sure to line them up with the settings already used in this repo so there weren't any changes when running the `format` command.