### PR TITLE
Import `json-to-go` from original repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "is-svg": "^4.3.1",
     "json-schema-to-typescript": "^10.1.4",
     "json-schema-to-zod": "^0.1.2",
-    "json-to-go": "gist:0d0b8324131c80eeb7e1df20001be32f",
+    "json-to-go": "https://github.com/mholt/json-to-go",
     "json-to-zod": "^1.1.2",
     "json-ts": "^1.6.4",
     "json_typegen_wasm": "^0.7.0",


### PR DESCRIPTION
We don't need to rely on a gist, we can import mholt's original repo directly.