### PR TITLE
feat: Adding JSON to Java transformation feature

### DIFF
--- a/pages/json-to-java.tsx
+++ b/pages/json-to-java.tsx
@@ -20,6 +20,7 @@ export default function JsonToJava() {
     let variableTypes: string[] = [];
 
     kotlinTransformationLines.forEach((line: string) => {
+      const originalLine = line;
       line = line.trim();
 
       if (line === ")") {
@@ -116,7 +117,7 @@ export default function JsonToJava() {
         javaTransformation += `${line};`;
       } else {
         // If there's any other line, it is most probably a 'next line character', so just append it
-        javaTransformation += line;
+        javaTransformation += originalLine;
       }
 
       javaTransformation += "\n";

--- a/pages/json-to-java.tsx
+++ b/pages/json-to-java.tsx
@@ -105,7 +105,7 @@ export default function JsonToJava() {
         const titleCaseVariable = className;
         const getters = `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
         const setters = `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
-        const constructor = `\tpublic ${className}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable}\n\t}\n`;
+        const constructor = `\tpublic ${className}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n`;
         javaTransformation += `public class ${className} {\n\tprivate ${type} ${variable};\n`;
         javaTransformation += `\n${constructor}\n${getters}${setters}}`;
       } else {

--- a/pages/json-to-java.tsx
+++ b/pages/json-to-java.tsx
@@ -1,0 +1,97 @@
+import ConversionPanel from "@components/ConversionPanel";
+import * as React from "react";
+import { useCallback } from "react";
+
+export default function JsonToJava() {
+  const transformer = useCallback(async ({ value }) => {
+    const { run } = await import("json_typegen_wasm");
+    const kotlinTransformationLines: string[] = run(
+      "Root",
+      value,
+      JSON.stringify({
+        output_mode: "kotlin"
+      })
+    ).split("\n");
+
+    // use Kotlin transformation to convert JSON to Java
+    let javaTransformation: string = "";
+    let getters: string = "";
+    let setters: string = "";
+
+    kotlinTransformationLines.forEach((line: string) => {
+      line = line.trim();
+
+      if (line === ")") {
+        // Class is closing so append the getters, setters for the current class,
+        // close the class and reset the getters, setters
+        javaTransformation += `\n${getters}${setters}}`;
+        getters = "";
+        setters = "";
+      } else if (line.startsWith("data class ")) {
+        // Change the start of a class from 'data class Root(' to 'public class Root {'
+        const classNameIndex = 11;
+        const classNameEndIndex = line.indexOf("(");
+        javaTransformation += `public class ${line.substring(
+          classNameIndex,
+          classNameEndIndex
+        )} {`;
+      } else if (line.startsWith("val")) {
+        // If this is a variable, change 'val name: String' to 'private String name;'
+        // followed by respective getters, setters for the variable
+        const processedLine = line.replace("?", "");
+        const variableStartIndex = 4; // length of string "val "
+        const variableEndIndex = processedLine.indexOf(":");
+        const variable: string = processedLine.substring(
+          variableStartIndex,
+          variableEndIndex
+        );
+        const typeStartIndex = processedLine.indexOf(":") + 2;
+        const type = processedLine.substring(
+          typeStartIndex,
+          processedLine.length - 1
+        );
+        const titleCaseVariable =
+          variable.charAt(0).toUpperCase() + variable.substring(1);
+        getters += `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
+        setters += `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
+        javaTransformation += `\tprivate ${type} ${variable};`;
+      } else if (line.startsWith("typealias")) {
+        // If this is a kotlin typealias, make it into a class
+        const classNameStartIndex = 10; // length of string "typealias "
+        const classNameEndIndex = line.indexOf(" =");
+        const className = line.substring(
+          classNameStartIndex,
+          classNameEndIndex
+        );
+        const typeNameEndIndex = line.indexOf("=") + 2;
+        const type = line.substring(typeNameEndIndex, line.length - 1); // ignore the semi-colon
+        const variable =
+          className.charAt(0).toLowerCase() + className.substring(1);
+        const titleCaseVariable = className;
+        getters = `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
+        setters = `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
+        javaTransformation += `public class ${className} {\n\tprivate ${type} ${variable};\n`;
+        javaTransformation += `\n${getters}${setters}}`;
+        getters = "";
+        setters = "";
+      } else {
+        // If there's any other line, it is most probably a 'next line character', so just append it
+        javaTransformation += line;
+      }
+
+      javaTransformation += "\n";
+    });
+
+    return javaTransformation;
+  }, []);
+
+  return (
+    <ConversionPanel
+      transformer={transformer}
+      editorTitle="JSON"
+      editorLanguage="json"
+      resultTitle="Java"
+      resultLanguage={"java"}
+    />
+  );
+}

--- a/pages/json-to-java.tsx
+++ b/pages/json-to-java.tsx
@@ -80,10 +80,14 @@ export default function JsonToJava() {
           variableEndIndex
         );
         const typeStartIndex = processedLine.indexOf(":") + 2;
-        const type = processedLine.substring(
+        let type: string = processedLine.substring(
           typeStartIndex,
           processedLine.length - 1
         );
+
+        // Update kotlin generic typing to Java generic typing
+        type = type.replace("<Any>?", "<?>");
+        type = type.replace("<Any>", "<?>");
 
         // Save variables and their types to be later used in constructor, getter, setter generation
         variableNames.push(variable);
@@ -108,6 +112,8 @@ export default function JsonToJava() {
         const constructor = `\tpublic ${className}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n`;
         javaTransformation += `public class ${className} {\n\tprivate ${type} ${variable};\n`;
         javaTransformation += `\n${constructor}\n${getters}${setters}}`;
+      } else if (line.startsWith("import")) {
+        javaTransformation += `${line};`;
       } else {
         // If there's any other line, it is most probably a 'next line character', so just append it
         javaTransformation += line;

--- a/pages/json-to-java.tsx
+++ b/pages/json-to-java.tsx
@@ -15,26 +15,60 @@ export default function JsonToJava() {
 
     // use Kotlin transformation to convert JSON to Java
     let javaTransformation: string = "";
-    let getters: string = "";
-    let setters: string = "";
+    let currentClass: string = "";
+    let variableNames: string[] = [];
+    let variableTypes: string[] = [];
 
     kotlinTransformationLines.forEach((line: string) => {
       line = line.trim();
 
       if (line === ")") {
-        // Class is closing so append the getters, setters for the current class,
-        // close the class and reset the getters, setters
-        javaTransformation += `\n${getters}${setters}}`;
-        getters = "";
-        setters = "";
+        // Class is closing so generate constructor, getters and setters for
+        // the current class, close the class and reset running values
+        let args: string[] = [];
+        let getters: string[] = [];
+        let setters: string[] = [];
+
+        // Create args for constructor, getters and setters
+        for (let i = 0; i < variableNames.length; i++) {
+          const type = variableTypes[i];
+          const variableName = variableNames[i];
+          const titleCaseVariable =
+            variableName.charAt(0).toUpperCase() + variableName.substring(1);
+          args.push(`${type} ${variableName}`);
+          getters.push(
+            `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variableName};\n\t}\n`
+          );
+          setters.push(
+            `\tpublic void set${titleCaseVariable}(${type} ${variableName}) {\n\t\tthis.${variableName} = ${variableName};\n\t}\n`
+          );
+        }
+
+        // Create constructor
+        let constructor = `\tpublic ${currentClass}(${args.join(", ")}) {`;
+        let properties: string[] = [];
+        variableNames.forEach(variable => {
+          properties.push(`this.${variable} = ${variable};`);
+        });
+        constructor += `\n\t\t${properties.join("\n\t\t")}\n\t}\n`;
+        javaTransformation += `\n${constructor}\n${getters.join(
+          "\n"
+        )}\n${setters.join("\n")}}`;
+
+        // Reset running values
+        currentClass = "";
+        variableNames = [];
+        variableTypes = [];
       } else if (line.startsWith("data class ")) {
         // Change the start of a class from 'data class Root(' to 'public class Root {'
-        const classNameIndex = 11;
+        const classNameStartIndex = 11;
         const classNameEndIndex = line.indexOf("(");
-        javaTransformation += `public class ${line.substring(
-          classNameIndex,
+        const className = line.substring(
+          classNameStartIndex,
           classNameEndIndex
-        )} {`;
+        );
+        javaTransformation += `public class ${className} {`;
+        currentClass = className;
       } else if (line.startsWith("val")) {
         // If this is a variable, change 'val name: String' to 'private String name;'
         // followed by respective getters, setters for the variable
@@ -50,10 +84,10 @@ export default function JsonToJava() {
           typeStartIndex,
           processedLine.length - 1
         );
-        const titleCaseVariable =
-          variable.charAt(0).toUpperCase() + variable.substring(1);
-        getters += `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
-        setters += `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
+
+        // Save variables and their types to be later used in constructor, getter, setter generation
+        variableNames.push(variable);
+        variableTypes.push(type);
         javaTransformation += `\tprivate ${type} ${variable};`;
       } else if (line.startsWith("typealias")) {
         // If this is a kotlin typealias, make it into a class
@@ -67,13 +101,13 @@ export default function JsonToJava() {
         const type = line.substring(typeNameEndIndex, line.length - 1); // ignore the semi-colon
         const variable =
           className.charAt(0).toLowerCase() + className.substring(1);
+
         const titleCaseVariable = className;
-        getters = `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
-        setters = `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
+        const getters = `\tpublic ${type} get${titleCaseVariable}() {\n\t\treturn this.${variable};\n\t}\n\n`;
+        const setters = `\tpublic void set${titleCaseVariable}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable};\n\t}\n\n`;
+        const constructor = `\tpublic ${className}(${type} ${variable}) {\n\t\tthis.${variable} = ${variable}\n\t}\n`;
         javaTransformation += `public class ${className} {\n\tprivate ${type} ${variable};\n`;
-        javaTransformation += `\n${getters}${setters}}`;
-        getters = "";
-        setters = "";
+        javaTransformation += `\n${constructor}\n${getters}${setters}}`;
       } else {
         // If there's any other line, it is most probably a 'next line character', so just append it
         javaTransformation += line;

--- a/utils/routes.tsx
+++ b/utils/routes.tsx
@@ -131,6 +131,12 @@ export const categorizedRoutes = [
         packageName: "json_typegen_wasm"
       },
       {
+        label: "to Java",
+        path: "/json-to-java",
+        packageUrl: "https://www.npmjs.com/package/json_typegen_wasm",
+        packageName: "json_typegen_wasm"
+      },
+      {
         label: "to JSON Schema",
         path: "/json-to-json-schema",
         packageUrl: "https://www.npmjs.com/package/json_typegen_wasm",


### PR DESCRIPTION
## Github issue
https://github.com/ritz078/transform/issues/335

## PR explanation

@ritz078  I am adding a JSON to Java transformation feature. I couldn't find any npm libraries that already do this so I used JSON to Kotlin transformation and applied rules to output Java class models.

I applied the below rules -

- Convert `data class <className>(` to `public class <className> {`
- For every variable `val <variableName>: <variableType>,` convert it to `private <variableType> <variableName>;`
- Add constructor, getters and setters for every variable, as is done in standard Java models
- If there's a kotlin typealias (created when the entire JSON object is an array), wrap the object in a class. E.g. for `typealias Root = List<Root2>` it will create a class root with just one list property and its getters, setters
- Append the constructor, getters setters and close the class when a ')' is found, i.e. kotlin data class end has been reached

I tested this locally with a variety of JSON samples and its working perfectly. Some of the samples I tried were from [this](https://stackoverflow.com/questions/10539797/complex-json-nesting-of-objects-and-arrays) StackOverflow answer, in case anyone would like to test this locally

Please review and let me know if any changes are required.