### PR TITLE
✨ add Json schema to Bigquery schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/SuttonJack"><img src="https://avatars.githubusercontent.com/u/92991945?v=4?s=100" width="100px;" alt="Jack Sutton"/><br /><sub><b>Jack Sutton</b></sub></a><br /><a href="https://github.com/ritz078/transform/commits?author=SuttonJack" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://t.me/jackardios"><img src="https://avatars.githubusercontent.com/u/24757335?v=4?s=100" width="100px;" alt="Salakhutdinov Salavat"/><br /><sub><b>Salakhutdinov Salavat</b></sub></a><br /><a href="https://github.com/ritz078/transform/commits?author=Jackardios" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://aalok.in"><img src="https://avatars.githubusercontent.com/u/4070844?v=4?s=100" width="100px;" alt="Aalok Kamble"/><br /><sub><b>Aalok Kamble</b></sub></a><br /><a href="https://github.com/ritz078/transform/commits?author=aalokkamble" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/pages/json-schema-to-bigquery.tsx
+++ b/pages/json-schema-to-bigquery.tsx
@@ -1,0 +1,110 @@
+import ConversionPanel from "@components/ConversionPanel";
+import * as React from "react";
+import { useCallback } from "react";
+
+interface JsonSchemaProperty {
+  description?: string;
+  nullable?: boolean;
+  type: string;
+  items?: JsonSchema;
+}
+
+interface JsonSchema {
+  properties: {
+    [key: string]: JsonSchemaProperty;
+  };
+  required?: string[];
+}
+
+interface BigQuerySchema {
+  name: string;
+  description?: string;
+  type: string;
+  mode?: string;
+  fields?: BigQuerySchema[];
+}
+
+function convertJsonSchemaToBigQuery(
+  jsonSchema: JsonSchema
+): { fields: BigQuerySchema[] } {
+  const bigquerySchema: BigQuerySchema[] = [];
+
+  // Loop through each field in the JSON schema object
+  for (let field in jsonSchema.properties) {
+    const schema: BigQuerySchema = {} as BigQuerySchema;
+
+    // Set the name of the field
+    schema.name = field;
+
+    // Set the description of the field, if available
+    if (jsonSchema.properties[field].description) {
+      schema.description = jsonSchema.properties[field].description;
+    }
+
+    // Set the required of the field, if available
+    if (jsonSchema.required && jsonSchema.required.includes(field)) {
+      schema.mode = "REQUIRED";
+    }
+    // Set the nullable of the field, if available
+    else if (jsonSchema.properties[field].nullable) {
+      schema.mode = "NULLABLE";
+    }
+
+    // Determine the type of the field
+    switch (jsonSchema.properties[field].type) {
+      case "string":
+        schema.type = "STRING";
+        break;
+      case "number":
+        schema.type = "FLOAT";
+        break;
+      case "integer":
+        schema.type = "INTEGER";
+        break;
+      case "boolean":
+        schema.type = "BOOLEAN";
+        break;
+      case "array":
+        schema.mode = "REPEATED";
+        schema.type = "RECORD";
+        schema.fields = convertJsonSchemaToBigQuery(
+          jsonSchema.properties[field].items
+        ).fields;
+        break;
+      case "object":
+        schema.type = "RECORD";
+        const subJsonSchema: JsonSchema = {
+          properties: { [field]: jsonSchema.properties[field] }
+        };
+        schema.fields = convertJsonSchemaToBigQuery(subJsonSchema).fields;
+        break;
+      default:
+        schema.type = "STRING";
+    }
+
+    // Add the schema to the BigQuery schema array
+    bigquerySchema.push(schema);
+  }
+
+  // Return the BigQuery schema object
+  return { fields: bigquerySchema };
+}
+
+export default function JsonSchemaToBigQuery() {
+  const transformer = useCallback(async ({ value }) => {
+    const jsonSchema: JsonSchema = JSON.parse(value);
+    const bigQueryFieldSchema = convertJsonSchemaToBigQuery(jsonSchema).fields;
+    return JSON.stringify(bigQueryFieldSchema);
+  }, []);
+
+  return (
+    <ConversionPanel
+      transformer={transformer}
+      editorTitle="JSON Schema"
+      editorLanguage="json"
+      editorDefaultValue="jsonSchema"
+      resultTitle="BigQuery Schema"
+      resultLanguage={"json"}
+    />
+  );
+}

--- a/utils/routes.tsx
+++ b/utils/routes.tsx
@@ -160,6 +160,12 @@ export const categorizedRoutes = [
     category: "JSON Schema",
     content: [
       {
+        label: "to BigQuery Schema",
+        path: "/json-schema-to-bigquery",
+        packageName: "json-schema-to-bigquery",
+        packageUrl: "https://github.com/aalokkamble/transform"
+      },
+      {
         label: "to TypeScript",
         path: "/json-schema-to-typescript",
         packageName: "json-schema-to-typescript",


### PR DESCRIPTION
Added new feature Json schema to Bigquery schema. Initial release.

Json schema reference: https://json-schema.org/
Bigquery Schema reference: https://cloud.google.com/bigquery/docs/schemas#creating_a_json_schema_file