### PR TITLE
remove svg-to-dataurl dependency

### DIFF
--- a/components/SvgConverter.tsx
+++ b/components/SvgConverter.tsx
@@ -4,7 +4,17 @@ import { EditorPanelProps } from "@components/EditorPanel";
 import Form from "@components/Form";
 import ConversionPanel, { Transformer } from "@components/ConversionPanel";
 import { Alert, Badge, Heading, Pane } from "evergreen-ui";
-import svgToDataUrl from "svg-to-dataurl";
+
+const svgToDataUrl = (svgStr: string) => {
+  const encoded = encodeURIComponent(svgStr)
+    .replace(/'/g, "%27")
+    .replace(/"/g, "%22");
+
+  const header = "data:image/svg+xml,";
+  const dataUrl = header + encoded;
+
+  return dataUrl;
+};
 
 interface SvgConverterProps {
   name: string;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "rust-keywords": "^1.1.0",
     "sha1": "^1.1.1",
     "stringify-object": "^3.3.0",
-    "svg-to-dataurl": "^1.0.0",
     "svgo": "^1.3.2",
     "tempy": "^1.0.1",
     "text-encoding-utf-8": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9429,11 +9429,6 @@ svg-parser@^2.0.2:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svg-to-dataurl@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/svg-to-dataurl/-/svg-to-dataurl-1.0.0.tgz#343f21a5dc3e051ae413c590cf478b7cf7a5f070"
-  integrity sha512-WrPB9vdd4RO0BjcPN6NJ9ofj3Zt8de16TJZ+JVJ4LnE2OKNGz+HjgGv6rE5Hp3s+OnM56X9i64mfJDU9uf4ZqQ==
-
 svgo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"


### PR DESCRIPTION
When running `yarn run build`:

```
info  - Collecting page data ..(node:13750) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/xxx/Projekte/experiments/transform/node_modules/svg-to-dataurl/package.json' of 'svg-to-dataurl'. Please either fix that or report it to the module author
```

https://github.com/F1LT3R/svg-to-dataurl/blob/master/index.js is basically a one-liner and only used in one place.

This PR removes/replaces it.