### PR TITLE
Adds YAML to Zod Schema, YAML category

### DIFF
--- a/pages/yaml-to-zod.tsx
+++ b/pages/yaml-to-zod.tsx
@@ -1,0 +1,64 @@
+import ConversionPanel from "@components/ConversionPanel";
+import { EditorPanelProps } from "@components/EditorPanel";
+import Form, { InputType } from "@components/Form";
+import { useSettings } from "@hooks/useSettings";
+import * as React from "react";
+import { useCallback } from "react";
+import yaml from "yaml";
+
+interface Settings {
+  rootName: string;
+}
+
+const formFields = [
+  {
+    type: InputType.TEXT_INPUT,
+    key: "rootName",
+    label: "Root Schema Name"
+  }
+];
+
+export default function YamlToZod() {
+  const name = "YAML to Zod Schema";
+
+  const [settings, setSettings] = useSettings(name, {
+    rootName: "schema"
+  });
+
+  const transformer = useCallback(
+    async ({ value }) => {
+      const yamlToJSON = JSON.stringify(yaml.parse(value));
+      const { jsonToZod } = await import("json-to-zod");
+      return jsonToZod(JSON.parse(yamlToJSON), settings.rootName, true);
+    },
+    [settings]
+  );
+
+  const getSettingsElement = useCallback<EditorPanelProps["settingElement"]>(
+    ({ open, toggle }) => {
+      return (
+        <Form<Settings>
+          title={name}
+          onSubmit={setSettings}
+          open={open}
+          toggle={toggle}
+          formsFields={formFields}
+          initialValues={settings}
+        />
+      );
+    },
+    []
+  );
+
+  return (
+    <ConversionPanel
+      transformer={transformer}
+      editorTitle="YAML"
+      editorLanguage="yaml"
+      resultTitle="Zod Schema"
+      resultLanguage={"typescript"}
+      editorSettingsElement={getSettingsElement}
+      settings={settings}
+    />
+  );
+}

--- a/utils/routes.tsx
+++ b/utils/routes.tsx
@@ -350,6 +350,26 @@ export const categorizedRoutes = [
     ]
   },
   {
+    category: "YAML",
+    iconName: "",
+    content: [
+      {
+        label: "to JSON",
+        path: "/yaml-to-json",
+        packageName: "yaml",
+        packageUrl: "https://github.com/tj/js-yaml"
+      },
+      {
+        label: "to TOML",
+        path: "/yaml-to-toml"
+      },
+      {
+        label: "to Zod Schema",
+        path: "/yaml-to-zod"
+      }
+    ]
+  },
+  {
     category: "Others",
     iconName: "",
     content: [
@@ -358,16 +378,6 @@ export const categorizedRoutes = [
         path: "/xml-to-json",
         packageName: "xml-js",
         packageUrl: "https://github.com/nashwaan/xml-js"
-      },
-      {
-        label: "YAML to JSON",
-        path: "/yaml-to-json",
-        packageName: "yaml",
-        packageUrl: "https://github.com/tj/js-yaml"
-      },
-      {
-        label: "YAML to TOML",
-        path: "/yaml-to-toml"
       },
       {
         label: "Markdown to HTML",
@@ -380,10 +390,6 @@ export const categorizedRoutes = [
         path: "/toml-to-json",
         packageUrl: "https://www.npmjs.com/package/@iarna/toml",
         packageName: "@iarna/toml"
-      },
-      {
-        label: "TOML to YAML",
-        path: "/toml-to-yaml"
       },
       {
         label: "Cadence to Go",


### PR DESCRIPTION
- Adds a YAML to Zod Schema transformer by first converting the YAML to JSON using the same method as the YAML to JSON transformer, then converting the JSON to Zod Schema using the same method as the JSON to Zod Schema transformer.
- Creates a new YAML category in the sidebar

## Problems with this PR ;)
The implementation in this PR works, but has some minor flaws that I need help fixing! It could be merged as is with these caveats:

* Doesn't define `packageName` or `packageUrl` in `routes.tsx` because it uses both the packages [json-to-zod](json-to-zod) and [yaml](https://github.com/tj/js-yaml).
   * To fix: Add a way to credit two packages at once, or implement a package that does a direct YAML to Zod Schema conversion.
* Reuses code from `YamlToJson()` and `JsonToZod()` without importing them.
    * To fix: Importing the functions `YamlToJson()` and `JsonToZod()` directly instead of being made up of their code.