### PR TITLE
feat: added new route for transforming js to zod directly

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+const crypto = require("crypto");
+const cryptoOrigCreateHash = crypto.createHash;
+crypto.createHash = algorithm =>
+  cryptoOrigCreateHash(algorithm === "md4" ? "sha256" : algorithm);
 const webpack = require("webpack");
 
 const config = {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:analyze": "ANALYZE=true yarn build"
   },
   "engines": {
-    "node": "18.x"
+    "node": "20.x"
   },
   "dependencies": {
     "@babel/plugin-transform-flow-strip-types": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "author": "ritz078 <rkritesh078@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "dev:inspect": "NODE_OPTIONS=\"--inspect\" next dev",
+    "dev:inspect": "NODE_OPTIONS=\"--inspect --openssl-legacy-provider\" next dev",
     "dev": "NODE_OPTIONS=\"--openssl-legacy-provider\" next dev",
     "start": "NODE_OPTIONS=\"--openssl-legacy-provider\" next start",
     "format": "prettier --write '**/*.ts' '**/*.tsx'",
     "build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
     "now-build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
     "postinstall": "patch-package",
-    "build:analyze": "NODE_OPTIONS=\"--openssl-legacy-provider\" ANALYZE=true yarn build"
+    "build:analyze": "ANALYZE=true yarn build"
   },
   "engines": {
     "node": "22.x"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "author": "ritz078 <rkritesh078@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "dev:inspect": "NODE_OPTIONS=\"--inspect --openssl-legacy-provider\" next dev",
-    "dev": "NODE_OPTIONS=\"--openssl-legacy-provider\" next dev",
-    "start": "NODE_OPTIONS=\"--openssl-legacy-provider\" next start",
+    "dev:inspect": "NODE_OPTIONS=\"--inspect\" next dev",
+    "dev": "next dev",
+    "start": "next start",
     "format": "prettier --write '**/*.ts' '**/*.tsx'",
-    "build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
-    "now-build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
+    "build": "next build",
+    "now-build": "next build",
     "postinstall": "patch-package",
     "build:analyze": "ANALYZE=true yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
   "license": "MIT",
   "scripts": {
     "dev:inspect": "NODE_OPTIONS=\"--inspect\" next dev",
-    "dev": "next dev",
-    "start": "next start",
+    "dev": "NODE_OPTIONS=\"--openssl-legacy-provider\" next dev",
+    "start": "NODE_OPTIONS=\"--openssl-legacy-provider\" next start",
     "format": "prettier --write '**/*.ts' '**/*.tsx'",
-    "build": "next build",
-    "now-build": "next build",
+    "build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
+    "now-build": "NODE_OPTIONS=\"--openssl-legacy-provider\" next build",
     "postinstall": "patch-package",
-    "build:analyze": "ANALYZE=true yarn build"
+    "build:analyze": "NODE_OPTIONS=\"--openssl-legacy-provider\" ANALYZE=true yarn build"
   },
   "engines": {
-    "node": "16.x"
+    "node": "22.x"
   },
   "dependencies": {
     "@babel/plugin-transform-flow-strip-types": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:analyze": "ANALYZE=true yarn build"
   },
   "engines": {
-    "node": "22.x"
+    "node": "18.x"
   },
   "dependencies": {
     "@babel/plugin-transform-flow-strip-types": "^7.16.0",

--- a/pages/js-object-to-zod.tsx
+++ b/pages/js-object-to-zod.tsx
@@ -1,0 +1,64 @@
+import ConversionPanel from "@components/ConversionPanel";
+import { EditorPanelProps } from "@components/EditorPanel";
+import Form, { InputType } from "@components/Form";
+import { useSettings } from "@hooks/useSettings";
+import * as React from "react";
+import { useCallback } from "react";
+
+interface Settings {
+  rootName: string;
+}
+
+const formFields = [
+  {
+    type: InputType.TEXT_INPUT,
+    key: "rootName",
+    label: "Root Schema Name"
+  }
+];
+
+export default function JsObjectToZod() {
+  const name = "JS Object to Zod Schema";
+
+  const [settings, setSettings] = useSettings(name, {
+    rootName: "schema"
+  });
+
+  const transformer = useCallback(
+    async ({ value }) => {
+      const { jsonToZod } = await import("json-to-zod");
+      const objectValue = eval("(" + value + ")");
+      return jsonToZod(objectValue, settings.rootName, true);
+    },
+    [settings]
+  );
+
+  const getSettingsElement = useCallback<EditorPanelProps["settingElement"]>(
+    ({ open, toggle }) => {
+      return (
+        <Form<Settings>
+          title={name}
+          onSubmit={setSettings}
+          open={open}
+          toggle={toggle}
+          formsFields={formFields}
+          initialValues={settings}
+        />
+      );
+    },
+    []
+  );
+
+  return (
+    <ConversionPanel
+      transformer={transformer}
+      editorTitle="JS Object"
+      editorLanguage="javascript"
+      editorDefaultValue="jsObject"
+      resultTitle="Zod Schema"
+      resultLanguage={"typescript"}
+      editorSettingsElement={getSettingsElement}
+      settings={settings}
+    />
+  );
+}

--- a/utils/routes.tsx
+++ b/utils/routes.tsx
@@ -223,6 +223,12 @@ export const categorizedRoutes = [
         path: "/js-object-to-typescript",
         desc: "An online REPL for converting JS Object to Typescript."
       },
+      {
+        label: "to Zod Schema",
+        path: "/js-object-to-zod",
+        packageUrl: "https://www.npmjs.com/package/json-to-zod",
+        packageName: "json-to-zod"
+      }
     ]
   },
   {


### PR DESCRIPTION
since "javascript to json" and "json to zod" are already supported, this is a shortcut I would like to have

Vercel only supports node v20 & v22, therefore i bumped the engine version and solved some conflicts too in order for a successfull prwview branch